### PR TITLE
fix: 좋아요/싫어요 버튼 양쪽 정렬 레이아웃 변경

### DIFF
--- a/src/components/sections/city-card.tsx
+++ b/src/components/sections/city-card.tsx
@@ -42,7 +42,7 @@ export function CityCard({ city }: CityCardProps) {
         </div>
 
         {/* 좋아요/싫어요 영역 */}
-        <div className="border-t px-4 py-3 flex items-center gap-4">
+        <div className="border-t px-4 py-3 flex items-center justify-between">
           <button
             onClick={(e) => {
               e.preventDefault();
@@ -66,8 +66,8 @@ export function CityCard({ city }: CityCardProps) {
               reaction === "dislike" ? "text-red-500" : "text-muted-foreground hover:text-foreground"
             }`}
           >
-            <ThumbsDown className="h-4 w-4" />
             <span>{dislikes}</span>
+            <ThumbsDown className="h-4 w-4" />
           </button>
         </div>
       </Card>


### PR DESCRIPTION
## Summary
- 도시 카드의 좋아요/싫어요 버튼을 양쪽 정렬(`justify-between`)로 변경
- 싫어요 버튼 내 아이콘/숫자 순서 반전: `[숫자][👎]`

Closes #3

## Test plan
- [ ] 좋아요 버튼이 왼쪽, 싫어요 버튼이 오른쪽에 배치되는지 확인
- [ ] 싫어요 버튼이 `[숫자][👎]` 순서로 표시되는지 확인
- [ ] `npm run build` 성공
- [ ] `npm run lint` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)