### PR TITLE
feat: 도시 상세 페이지 구현 (closes #9)

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/cities/[slug]/page.tsx
+++ b/src/app/cities/[slug]/page.tsx
@@ -12,6 +12,7 @@ import {
   Train,
   MapPin,
   DollarSign,
+  Star,
 } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { CityDetailReaction } from "@/components/sections/city-detail-reaction";
@@ -38,6 +39,8 @@ export async function generateMetadata({
 }
 
 const stats = [
+  { key: "kNomadScore", label: "노마드 점수", icon: Star, unit: "점" },
+  { key: "monthlyCost", label: "월 생활비", icon: DollarSign, unit: "", format: (v: number) => `${Math.round(v / 10000)}만원` },
   { key: "internetSpeed", label: "인터넷", icon: Wifi, unit: "Mbps" },
   { key: "cafeScore", label: "카페 점수", icon: Coffee, unit: "점" },
   { key: "temperature", label: "평균 기온", icon: Thermometer, unit: "°C" },
@@ -109,12 +112,13 @@ export default async function CityPage({ params }: CityPageProps) {
         ))}
       </div>
 
-      {/* 상세 스탯 */}
+      {/* 상세 스탯 (8개) */}
       <Card className="p-6 mb-8">
         <h2 className="mb-4 text-lg font-semibold">상세 정보</h2>
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-          {stats.map(({ key, label, icon: Icon, unit }) => {
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          {stats.map(({ key, label, icon: Icon, unit, ...rest }) => {
             const value = city[key];
+            const formatted = "format" in rest ? (rest as { format: (v: number) => string }).format(value as number) : unit ? `${value} ${unit}` : `${value}`;
             return (
               <div key={key} className="flex items-center gap-3">
                 <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-muted">
@@ -122,10 +126,7 @@ export default async function CityPage({ params }: CityPageProps) {
                 </div>
                 <div>
                   <p className="text-xs text-muted-foreground">{label}</p>
-                  <p className="text-sm font-semibold">
-                    {value}
-                    {unit && ` ${unit}`}
-                  </p>
+                  <p className="text-sm font-semibold">{formatted}</p>
                 </div>
               </div>
             );

--- a/src/lib/cities.ts
+++ b/src/lib/cities.ts
@@ -2,7 +2,7 @@ import { cities } from "@/data/cities";
 import type { City } from "@/types";
 
 export function toSlug(cityNameEn: string): string {
-  return cityNameEn.toLowerCase();
+  return cityNameEn.toLowerCase().replace(/\s+/g, "-");
 }
 
 export function getCityBySlug(slug: string): City | undefined {


### PR DESCRIPTION
## Summary
- `/cities/[slug]` 상세 페이지 신규 생성 (뒤로가기 링크, 히어로, 메트릭 8개, 기본정보)
- `CityDetailReaction` 컴포넌트 추가 (`useReaction` hook 재사용)
- `CityCard`에 상세 페이지 Link 추가 + 좋아요/싫어요 이벤트 전파 방지

## Test plan
- [ ] `npm run build` 성공
- [ ] `npm run lint` 통과
- [ ] 홈 카드 클릭 → `/cities/[slug]` 이동 확인
- [ ] 상세 페이지 뒤로가기 링크 → `/` 이동 확인
- [ ] 좋아요/싫어요 토글 정상 동작
- [ ] 메트릭 8개 모두 표시 확인 (kNomadScore, monthlyCost 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)