### PR TITLE
feat: 도시 데이터 Supabase 조회 전환 (Phase 10)

### DIFF
--- a/src/app/cities/[slug]/page.tsx
+++ b/src/app/cities/[slug]/page.tsx
@@ -22,14 +22,15 @@ interface CityPageProps {
 }
 
 export async function generateStaticParams() {
-  return getAllCitySlugs().map((slug) => ({ slug }));
+  const slugs = await getAllCitySlugs();
+  return slugs.map((slug) => ({ slug }));
 }
 
 export async function generateMetadata({
   params,
 }: CityPageProps): Promise<Metadata> {
   const { slug } = await params;
-  const city = getCityBySlug(slug);
+  const city = await getCityBySlug(slug);
   if (!city) return {};
 
   return {
@@ -51,7 +52,7 @@ const stats = [
 
 export default async function CityPage({ params }: CityPageProps) {
   const { slug } = await params;
-  const city = getCityBySlug(slug);
+  const city = await getCityBySlug(slug);
 
   if (!city) notFound();
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,10 @@
 import { Hero } from "@/components/sections/hero";
 import { CitySection } from "@/components/sections/city-section";
-import { cities } from "@/data/cities";
+import { getCities } from "@/lib/cities";
 
-export default function HomePage() {
+export default async function HomePage() {
+  const cities = await getCities();
+
   return (
     <>
       <Hero />

--- a/src/data/cities.ts
+++ b/src/data/cities.ts
@@ -1,6 +1,7 @@
-import { City } from "@/types";
+import type { City } from "@/types";
 
-export const cities: City[] = [
+/** 시드 데이터 전용 — 프로덕션 코드에서 import 금지 (Supabase 조회 사용) */
+export const cities: Omit<City, "id">[] = [
   {
     cityName: "제주",
     cityNameEn: "Jeju",

--- a/src/lib/cities.ts
+++ b/src/lib/cities.ts
@@ -1,14 +1,84 @@
-import { cities } from "@/data/cities";
-import type { City } from "@/types";
+import { createClient } from "@/lib/supabase/server";
+import type { City, Region, Environment, Season, BudgetRange } from "@/types";
 
-export function toSlug(cityNameEn: string): string {
-  return cityNameEn.toLowerCase().replace(/\s+/g, "-");
+interface CityRow {
+  id: string;
+  city_name: string;
+  city_name_en: string;
+  slug: string;
+  image_url: string | null;
+  k_nomad_score: number;
+  monthly_cost: number;
+  internet_speed: number;
+  cafe_score: number;
+  temperature: number;
+  aqi: number;
+  safety_score: number;
+  ktx_to_seoul: string;
+  region: string;
+  environment: string[];
+  best_season: string[];
+  budget_range: string;
+  likes: number;
+  dislikes: number;
 }
 
-export function getCityBySlug(slug: string): City | undefined {
-  return cities.find((city) => toSlug(city.cityNameEn) === slug);
+function mapCityRow(row: CityRow): City {
+  return {
+    id: row.id,
+    cityName: row.city_name,
+    cityNameEn: row.city_name_en,
+    imageUrl: row.image_url ?? "",
+    kNomadScore: row.k_nomad_score,
+    monthlyCost: row.monthly_cost,
+    internetSpeed: row.internet_speed,
+    cafeScore: row.cafe_score,
+    temperature: row.temperature,
+    aqi: row.aqi,
+    safetyScore: row.safety_score,
+    ktxToSeoul: row.ktx_to_seoul,
+    region: row.region as Region,
+    environment: row.environment as Environment[],
+    bestSeason: row.best_season as Season[],
+    budgetRange: row.budget_range as BudgetRange,
+    likes: row.likes,
+    dislikes: row.dislikes,
+  };
 }
 
-export function getAllCitySlugs(): string[] {
-  return cities.map((city) => toSlug(city.cityNameEn));
+export async function getCities(): Promise<City[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase.from("cities").select("*");
+
+  if (error) {
+    console.error("getCities error:", error.message);
+    return [];
+  }
+
+  return (data as CityRow[]).map(mapCityRow);
+}
+
+export async function getCityBySlug(slug: string): Promise<City | undefined> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("cities")
+    .select("*")
+    .eq("slug", slug)
+    .single();
+
+  if (error || !data) return undefined;
+
+  return mapCityRow(data as CityRow);
+}
+
+export async function getAllCitySlugs(): Promise<string[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase.from("cities").select("slug");
+
+  if (error) {
+    console.error("getAllCitySlugs error:", error.message);
+    return [];
+  }
+
+  return (data as { slug: string }[]).map((row) => row.slug);
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,7 @@ export type Season = "봄" | "여름" | "가을" | "겨울";
 export type BudgetRange = "100만원 이하" | "100~200만원" | "200만원 이상";
 
 export interface City {
-  id?: string;
+  id: string;
   cityName: string;
   cityNameEn: string;
   imageUrl: string;


### PR DESCRIPTION
## Summary
- Mock 데이터 import(`src/data/cities.ts`)를 Supabase 서버 쿼리로 교체
- `getCities`, `getCityBySlug`, `getAllCitySlugs`를 async 함수로 전환
- snake_case → camelCase 변환 헬퍼(`mapCityRow`) 추가
- `City.id`를 required로 강화, Mock 데이터는 `Omit<City, "id">` 타입으로 분리

## 변경 파일
| 파일 | 변경 내용 |
|---|---|
| `src/lib/cities.ts` | Supabase 서버 쿼리 + `CityRow` 인터페이스 + `mapCityRow` 헬퍼 |
| `src/app/page.tsx` | async 전환, `await getCities()` 호출 |
| `src/app/cities/[slug]/page.tsx` | `await` 추가 (generateStaticParams, generateMetadata, CityPage) |
| `src/types/index.ts` | `id?: string` → `id: string` (required) |
| `src/data/cities.ts` | `Omit<City, "id">[]` 타입 + 시드 전용 주석 |

## 전제조건
- Phase 9 (#11) 완료 — Supabase cities 테이블 + 시드 데이터 존재 필요

## Test plan
- [ ] `npm run build` 성공
- [ ] `npm run lint` 통과
- [ ] 홈페이지에서 12개 도시가 Supabase에서 조회되어 표시
- [ ] 필터링 정상 동작
- [ ] 상세 페이지(`/cities/[slug]`) 정상 동작

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)