### PR TITLE
feat: 좋아요/싫어요 Supabase 저장 (Phase 11)

### DIFF
--- a/src/app/cities/[slug]/page.tsx
+++ b/src/app/cities/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { getCityBySlug, getAllCitySlugs } from "@/lib/cities";
+import { getCityBySlug, getUserReactionForCity } from "@/lib/cities";
 import {
   ArrowLeft,
   Wifi,
@@ -19,11 +19,6 @@ import { CityDetailReaction } from "@/components/sections/city-detail-reaction";
 
 interface CityPageProps {
   params: Promise<{ slug: string }>;
-}
-
-export async function generateStaticParams() {
-  const slugs = await getAllCitySlugs();
-  return slugs.map((slug) => ({ slug }));
 }
 
 export async function generateMetadata({
@@ -55,6 +50,8 @@ export default async function CityPage({ params }: CityPageProps) {
   const city = await getCityBySlug(slug);
 
   if (!city) notFound();
+
+  const userReaction = await getUserReactionForCity(city.id);
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-12">
@@ -136,7 +133,7 @@ export default async function CityPage({ params }: CityPageProps) {
       </Card>
 
       {/* 좋아요/싫어요 */}
-      <CityDetailReaction likes={city.likes} dislikes={city.dislikes} />
+      <CityDetailReaction cityId={city.id} likes={city.likes} dislikes={city.dislikes} userReaction={userReaction} />
     </main>
   );
 }

--- a/src/app/cities/actions.ts
+++ b/src/app/cities/actions.ts
@@ -1,0 +1,90 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+
+export type ReactionType = "like" | "dislike" | null;
+
+interface ToggleReactionResult {
+  likes: number;
+  dislikes: number;
+  userReaction: ReactionType;
+  error?: string;
+}
+
+export async function toggleReaction(
+  cityId: string,
+  reactionType: "like" | "dislike"
+): Promise<ToggleReactionResult> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { likes: 0, dislikes: 0, userReaction: null, error: "unauthenticated" };
+  }
+
+  // 현재 반응 조회
+  const { data: existing } = await supabase
+    .from("city_reactions")
+    .select("id, reaction_type")
+    .eq("user_id", user.id)
+    .eq("city_id", cityId)
+    .single();
+
+  if (existing?.reaction_type === reactionType) {
+    // 같은 반응 다시 클릭 → 삭제 (토글 off)
+    await supabase.from("city_reactions").delete().eq("id", existing.id);
+  } else if (existing) {
+    // 다른 반응으로 변경
+    await supabase
+      .from("city_reactions")
+      .update({ reaction_type: reactionType })
+      .eq("id", existing.id);
+  } else {
+    // 새 반응 생성
+    await supabase.from("city_reactions").insert({
+      user_id: user.id,
+      city_id: cityId,
+      reaction_type: reactionType,
+    });
+  }
+
+  // 카운트 재계산
+  const [{ count: likeCount }, { count: dislikeCount }] = await Promise.all([
+    supabase
+      .from("city_reactions")
+      .select("*", { count: "exact", head: true })
+      .eq("city_id", cityId)
+      .eq("reaction_type", "like"),
+    supabase
+      .from("city_reactions")
+      .select("*", { count: "exact", head: true })
+      .eq("city_id", cityId)
+      .eq("reaction_type", "dislike"),
+  ]);
+
+  const newLikes = likeCount ?? 0;
+  const newDislikes = dislikeCount ?? 0;
+
+  // cities 테이블 카운트 업데이트
+  await supabase
+    .from("cities")
+    .update({ likes: newLikes, dislikes: newDislikes })
+    .eq("id", cityId);
+
+  // 현재 사용자 반응 다시 확인
+  const { data: updated } = await supabase
+    .from("city_reactions")
+    .select("reaction_type")
+    .eq("user_id", user.id)
+    .eq("city_id", cityId)
+    .single();
+
+  return {
+    likes: newLikes,
+    dislikes: newDislikes,
+    userReaction: (updated?.reaction_type as ReactionType) ?? null,
+  };
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,17 @@
 import { Hero } from "@/components/sections/hero";
 import { CitySection } from "@/components/sections/city-section";
-import { getCities } from "@/lib/cities";
+import { getCities, getUserReactions } from "@/lib/cities";
 
 export default async function HomePage() {
-  const cities = await getCities();
+  const [cities, userReactions] = await Promise.all([
+    getCities(),
+    getUserReactions(),
+  ]);
 
   return (
     <>
       <Hero />
-      <CitySection cities={cities} />
+      <CitySection cities={cities} userReactions={userReactions} />
     </>
   );
 }

--- a/src/components/sections/city-card.tsx
+++ b/src/components/sections/city-card.tsx
@@ -5,15 +5,22 @@ import { ThumbsUp, ThumbsDown } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { City } from "@/types";
 import { useReaction } from "@/hooks/useReaction";
-import { toSlug } from "@/lib/cities";
+import { toSlug } from "@/lib/slug";
+import type { ReactionType } from "@/app/cities/actions";
 
 interface CityCardProps {
   city: City;
+  userReaction?: ReactionType;
 }
 
-export function CityCard({ city }: CityCardProps) {
+export function CityCard({ city, userReaction }: CityCardProps) {
   const { reaction, likes, dislikes, handleLike, handleDislike } =
-    useReaction(city.likes, city.dislikes);
+    useReaction({
+      cityId: city.id,
+      initialLikes: city.likes,
+      initialDislikes: city.dislikes,
+      initialReaction: userReaction,
+    });
 
   return (
     <Link href={`/cities/${toSlug(city.cityNameEn)}`} className="block">

--- a/src/components/sections/city-detail-reaction.tsx
+++ b/src/components/sections/city-detail-reaction.tsx
@@ -2,18 +2,28 @@
 
 import { ThumbsUp, ThumbsDown } from "lucide-react";
 import { useReaction } from "@/hooks/useReaction";
+import type { ReactionType } from "@/app/cities/actions";
 
 interface CityDetailReactionProps {
+  cityId: string;
   likes: number;
   dislikes: number;
+  userReaction?: ReactionType;
 }
 
 export function CityDetailReaction({
+  cityId,
   likes: initialLikes,
   dislikes: initialDislikes,
+  userReaction,
 }: CityDetailReactionProps) {
   const { reaction, likes, dislikes, handleLike, handleDislike } =
-    useReaction(initialLikes, initialDislikes);
+    useReaction({
+      cityId,
+      initialLikes,
+      initialDislikes,
+      initialReaction: userReaction,
+    });
 
   return (
     <section className="flex items-center gap-6">

--- a/src/components/sections/city-grid.tsx
+++ b/src/components/sections/city-grid.tsx
@@ -3,9 +3,10 @@ import { City } from "@/types";
 
 interface CityGridProps {
   cities: City[];
+  userReactions?: Record<string, "like" | "dislike">;
 }
 
-export function CityGrid({ cities }: CityGridProps) {
+export function CityGrid({ cities, userReactions }: CityGridProps) {
   return (
     <section id="cities" className="py-8 sm:py-12">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -17,7 +18,11 @@ export function CityGrid({ cities }: CityGridProps) {
         ) : (
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
             {cities.map((city) => (
-              <CityCard key={city.cityName} city={city} />
+              <CityCard
+                key={city.id}
+                city={city}
+                userReaction={userReactions?.[city.id]}
+              />
             ))}
           </div>
         )}

--- a/src/components/sections/city-section.tsx
+++ b/src/components/sections/city-section.tsx
@@ -7,15 +7,16 @@ import { CityGrid } from "./city-grid";
 
 interface CitySectionProps {
   cities: City[];
+  userReactions?: Record<string, "like" | "dislike">;
 }
 
-export function CitySection({ cities }: CitySectionProps) {
+export function CitySection({ cities, userReactions }: CitySectionProps) {
   const { filters, setFilters, filteredCities } = useCityFilter(cities);
 
   return (
     <>
       <FilterBar filters={filters} onFilterChange={setFilters} />
-      <CityGrid cities={filteredCities} />
+      <CityGrid cities={filteredCities} userReactions={userReactions} />
     </>
   );
 }

--- a/src/hooks/useReaction.ts
+++ b/src/hooks/useReaction.ts
@@ -1,35 +1,75 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toggleReaction, type ReactionType } from "@/app/cities/actions";
 
-type ReactionType = "like" | "dislike" | null;
+interface UseReactionOptions {
+  cityId: string;
+  initialLikes: number;
+  initialDislikes: number;
+  initialReaction?: ReactionType;
+}
 
-export function useReaction(initialLikes: number, initialDislikes: number) {
-  const [reaction, setReaction] = useState<ReactionType>(null);
+export function useReaction({
+  cityId,
+  initialLikes,
+  initialDislikes,
+  initialReaction = null,
+}: UseReactionOptions) {
+  const router = useRouter();
+  const [reaction, setReaction] = useState<ReactionType>(initialReaction);
   const [likes, setLikes] = useState(initialLikes);
   const [dislikes, setDislikes] = useState(initialDislikes);
+  const [isPending, startTransition] = useTransition();
+
+  function handleReaction(type: "like" | "dislike") {
+    // 낙관적 업데이트를 위한 이전 상태 저장
+    const prevReaction = reaction;
+    const prevLikes = likes;
+    const prevDislikes = dislikes;
+
+    // 낙관적 UI 업데이트
+    if (reaction === type) {
+      // 토글 off
+      setReaction(null);
+      if (type === "like") setLikes((v) => v - 1);
+      else setDislikes((v) => v - 1);
+    } else {
+      // 새 반응 또는 변경
+      if (reaction === "like") setLikes((v) => v - 1);
+      if (reaction === "dislike") setDislikes((v) => v - 1);
+      setReaction(type);
+      if (type === "like") setLikes((v) => v + 1);
+      else setDislikes((v) => v + 1);
+    }
+
+    startTransition(async () => {
+      const result = await toggleReaction(cityId, type);
+
+      if (result.error === "unauthenticated") {
+        // 롤백 후 로그인 페이지로
+        setReaction(prevReaction);
+        setLikes(prevLikes);
+        setDislikes(prevDislikes);
+        router.push("/login");
+        return;
+      }
+
+      // 서버 결과로 동기화
+      setLikes(result.likes);
+      setDislikes(result.dislikes);
+      setReaction(result.userReaction);
+    });
+  }
 
   function handleLike() {
-    if (reaction === "like") {
-      setReaction(null);
-      setLikes((v) => v - 1);
-    } else {
-      if (reaction === "dislike") setDislikes((v) => v - 1);
-      setReaction("like");
-      setLikes((v) => v + 1);
-    }
+    handleReaction("like");
   }
 
   function handleDislike() {
-    if (reaction === "dislike") {
-      setReaction(null);
-      setDislikes((v) => v - 1);
-    } else {
-      if (reaction === "like") setLikes((v) => v - 1);
-      setReaction("dislike");
-      setDislikes((v) => v + 1);
-    }
+    handleReaction("dislike");
   }
 
-  return { reaction, likes, dislikes, handleLike, handleDislike };
+  return { reaction, likes, dislikes, handleLike, handleDislike, isPending };
 }

--- a/src/lib/cities.ts
+++ b/src/lib/cities.ts
@@ -71,6 +71,48 @@ export async function getCityBySlug(slug: string): Promise<City | undefined> {
   return mapCityRow(data as CityRow);
 }
 
+export async function getUserReactions(): Promise<Record<string, "like" | "dislike">> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return {};
+
+  const { data, error } = await supabase
+    .from("city_reactions")
+    .select("city_id, reaction_type")
+    .eq("user_id", user.id);
+
+  if (error || !data) return {};
+
+  const map: Record<string, "like" | "dislike"> = {};
+  for (const row of data) {
+    map[row.city_id] = row.reaction_type as "like" | "dislike";
+  }
+  return map;
+}
+
+export async function getUserReactionForCity(
+  cityId: string
+): Promise<"like" | "dislike" | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return null;
+
+  const { data } = await supabase
+    .from("city_reactions")
+    .select("reaction_type")
+    .eq("user_id", user.id)
+    .eq("city_id", cityId)
+    .single();
+
+  return (data?.reaction_type as "like" | "dislike") ?? null;
+}
+
 export async function getAllCitySlugs(): Promise<string[]> {
   const supabase = await createClient();
   const { data, error } = await supabase.from("cities").select("slug");

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,0 +1,3 @@
+export function toSlug(cityNameEn: string): string {
+  return cityNameEn.toLowerCase().replace(/\s+/g, "-");
+}


### PR DESCRIPTION
## Summary
- `toggleReaction` Server Action 생성 — 인증 확인, city_reactions upsert/delete, 카운트 재계산
- `useReaction` hook 낙관적 업데이트 + Server Action 연동, 실패 시 rollback
- 비인증 사용자 좋아요/싫어요 클릭 시 `/login` 리다이렉트
- 홈/상세 페이지에서 사용자별 반응 상태 조회 후 컴포넌트에 전달

## 변경 파일
| 파일 | 변경 |
|---|---|
| `src/app/cities/actions.ts` (신규) | toggleReaction Server Action |
| `src/lib/slug.ts` (신규) | toSlug 유틸 (클라이언트 접근 가능) |
| `src/hooks/useReaction.ts` | 낙관적 업데이트 + Server Action 호출 |
| `src/components/sections/city-card.tsx` | userReaction props 추가 |
| `src/components/sections/city-detail-reaction.tsx` | cityId/userReaction props 추가 |
| `src/components/sections/city-grid.tsx` | userReactions 전달 |
| `src/components/sections/city-section.tsx` | userReactions 전달 |
| `src/lib/cities.ts` | getUserReactions, getUserReactionForCity 추가 |
| `src/app/page.tsx` | 사용자 반응 조회 연동 |
| `src/app/cities/[slug]/page.tsx` | 사용자 반응 조회 연동, generateStaticParams 제거 |

## Test plan
- [ ] 로그인 상태에서 좋아요 클릭 → DB 저장, 새로고침 후 유지 확인
- [ ] 비인증 상태에서 좋아요 클릭 → /login 리다이렉트 확인
- [ ] 홈 ↔ 상세 페이지 간 좋아요 상태 동기화 확인
- [ ] `npm run build` 성공
- [ ] `npm run lint` 통과

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)