### PR TITLE
improvement: 필터 바 드롭다운 전환 (#18)

### DIFF
--- a/src/components/sections/filter-bar.tsx
+++ b/src/components/sections/filter-bar.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import { FILTER_DEFINITIONS, type FilterDefinition } from "@/config/filter-config";
+import { FILTER_DEFINITIONS } from "@/config/filter-config";
 import type { Filters } from "@/hooks/useCityFilter";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 interface FilterBarProps {
   filters: Filters;
@@ -9,77 +16,29 @@ interface FilterBarProps {
 }
 
 export function FilterBar({ filters, onFilterChange }: FilterBarProps) {
-  function handleSelect(def: FilterDefinition, value: string) {
-    if (def.type === "single") {
-      onFilterChange({ ...filters, [def.key]: [value] });
-      return;
-    }
-
-    // multi select
-    if (value === "전체") {
-      onFilterChange({ ...filters, [def.key]: ["전체"] });
-      return;
-    }
-    const current = (filters[def.key] ?? []).filter((v) => v !== "전체");
-    const next = current.includes(value)
-      ? current.filter((v) => v !== value)
-      : [...current, value];
-    onFilterChange({
-      ...filters,
-      [def.key]: next.length === 0 ? ["전체"] : next,
-    });
-  }
-
   return (
     <div className="sticky top-16 z-40 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-4 space-y-3">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-4 flex items-center gap-4 flex-wrap">
         {FILTER_DEFINITIONS.map((def) => (
-          <FilterGroup
+          <Select
             key={def.key}
-            label={def.label}
-            options={def.options}
-            selected={filters[def.key] ?? ["전체"]}
-            onSelect={(v) => handleSelect(def, v)}
-          />
+            value={filters[def.key] ?? "전체"}
+            onValueChange={(value) =>
+              onFilterChange({ ...filters, [def.key]: value as string })
+            }
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {def.options.map((option) => (
+                <SelectItem key={option} value={option}>
+                  {option}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         ))}
-      </div>
-    </div>
-  );
-}
-
-function FilterGroup({
-  label,
-  options,
-  selected,
-  onSelect,
-}: {
-  label: string;
-  options: readonly string[];
-  selected: string[];
-  onSelect: (value: string) => void;
-}) {
-  return (
-    <div className="flex items-center gap-2 flex-wrap">
-      <span className="text-sm font-medium text-muted-foreground w-16 shrink-0">
-        {label}
-      </span>
-      <div className="flex gap-1.5 flex-1">
-        {options.map((option) => {
-          const isActive = selected.includes(option);
-          return (
-            <button
-              key={option}
-              onClick={() => onSelect(option)}
-              className={`flex-1 text-center px-3 py-1 rounded-full text-sm transition-colors ${
-                isActive
-                  ? "bg-primary text-primary-foreground"
-                  : "bg-muted text-muted-foreground hover:bg-muted/80"
-              }`}
-            >
-              {option}
-            </button>
-          );
-        })}
       </div>
     </div>
   );

--- a/src/config/filter-config.ts
+++ b/src/config/filter-config.ts
@@ -4,8 +4,7 @@ export interface FilterDefinition {
   key: string;
   label: string;
   options: readonly string[];
-  type: "single" | "multi";
-  match: (city: City, selected: string[]) => boolean;
+  match: (city: City, selected: string) => boolean;
 }
 
 export const FILTER_DEFINITIONS: FilterDefinition[] = [
@@ -13,34 +12,30 @@ export const FILTER_DEFINITIONS: FilterDefinition[] = [
     key: "budget",
     label: "예산",
     options: ["전체", "100만원 이하", "100~200만원", "200만원 이상"],
-    type: "single",
     match: (city, selected) =>
-      selected.includes("전체") || selected.includes(city.budgetRange),
+      selected === "전체" || selected === city.budgetRange,
   },
   {
     key: "region",
     label: "지역",
     options: ["전체", "수도권", "경상도", "전라도", "강원도", "제주도", "충청도"],
-    type: "single",
     match: (city, selected) =>
-      selected.includes("전체") || selected.includes(city.region),
+      selected === "전체" || selected === city.region,
   },
   {
     key: "environment",
     label: "환경",
     options: ["전체", "자연친화", "도심선호", "카페작업", "코워킹 필수"],
-    type: "multi",
     match: (city, selected) =>
-      selected.includes("전체") ||
-      selected.some((v) => city.environment.includes(v as typeof city.environment[number])),
+      selected === "전체" ||
+      city.environment.includes(selected as typeof city.environment[number]),
   },
   {
     key: "bestSeason",
     label: "최고 계절",
     options: ["전체", "봄", "여름", "가을", "겨울"],
-    type: "single",
     match: (city, selected) =>
-      selected.includes("전체") ||
-      selected.some((v) => city.bestSeason.includes(v as typeof city.bestSeason[number])),
+      selected === "전체" ||
+      city.bestSeason.includes(selected as typeof city.bestSeason[number]),
   },
 ];

--- a/src/hooks/useCityFilter.ts
+++ b/src/hooks/useCityFilter.ts
@@ -4,12 +4,12 @@ import { useState, useMemo } from "react";
 import { City } from "@/types";
 import { FILTER_DEFINITIONS } from "@/config/filter-config";
 
-export type Filters = Record<string, string[]>;
+export type Filters = Record<string, string>;
 
 function createDefaultFilters(): Filters {
   const defaults: Filters = {};
   for (const def of FILTER_DEFINITIONS) {
-    defaults[def.key] = ["전체"];
+    defaults[def.key] = "전체";
   }
   return defaults;
 }
@@ -20,7 +20,7 @@ export function useCityFilter(cities: City[]) {
   const filteredCities = useMemo(() => {
     return cities
       .filter((city) =>
-        FILTER_DEFINITIONS.every((def) => def.match(city, filters[def.key] ?? ["전체"]))
+        FILTER_DEFINITIONS.every((def) => def.match(city, filters[def.key] ?? "전체"))
       )
       .sort((a, b) => b.likes - a.likes);
   }, [cities, filters]);


### PR DESCRIPTION
## Summary
- 4행 버튼 그룹 필터를 한 줄 shadcn/ui Select 드롭다운 4개로 변경
- 환경 필터를 다중 선택에서 단일 선택으로 변경
- `Filters` 타입 단순화 (`Record<string, string[]>` → `Record<string, string>`)

## Test plan
- [ ] 모든 필터가 Select 드롭다운으로 표시되는지 확인
- [ ] 한 줄 레이아웃 정상 렌더링 확인
- [ ] 각 필터 선택 시 도시 목록 정상 필터링 확인
- [ ] 기본값 "전체" 선택 시 모든 도시 표시 확인
- [ ] `npm run build` 성공
- [ ] `npm run lint` 통과

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)